### PR TITLE
Enable legacy OpenSSL provider for Vue CLI build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
Updated the `serve` and `build` npm scripts to use the `--openssl-legacy-provider` Node.js option, enabling compatibility with legacy OpenSSL functionality.

## Changes
- Modified `serve` script to include `NODE_OPTIONS=--openssl-legacy-provider` flag
- Modified `build` script to include `NODE_OPTIONS=--openssl-legacy-provider` flag

## Details
This change addresses OpenSSL compatibility issues that can occur when using newer versions of Node.js (17+) with Vue CLI and its dependencies. The legacy provider flag allows the build tools to use older OpenSSL algorithms that may be required by certain dependencies, preventing build failures related to OpenSSL configuration.

https://claude.ai/code/session_01DrDwZWRD2aBbMAkn1CA7KP