### PR TITLE
Add live preview row showing calculated value as user types

### DIFF
--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="calculator">
+    <div class="preview">{{preview}}</div>
     <div class="display">{{current || '0'}}</div>
     <div @click="clear" class="btn">C</div>
     <div @click="sign" class="btn">+/-</div>
@@ -32,6 +33,19 @@ export default {
       operatorClicked: false,
       operator: null,
     }
+  },
+  computed: {
+    preview() {
+      if (this.previous !== null && this.operator !== null && this.current !== '' && !this.operatorClicked) {
+        const a = parseFloat(this.previous);
+        const b = parseFloat(this.current);
+        if (isNaN(a) || isNaN(b)) return '';
+        const result = this.operator(a, b);
+        if (!isFinite(result)) return '';
+        return `${result}`;
+      }
+      return '';
+    },
   },
   methods: {
     clear() {
@@ -78,8 +92,8 @@ export default {
     },
     equals() {
       this.current = `${this.operator(
-        parseFloat(this.current),
-        parseFloat(this.previous)
+        parseFloat(this.previous),
+        parseFloat(this.current)
         )}`;
         this.previous = null;
     },
@@ -95,6 +109,16 @@ export default {
   grid-auto-rows: minmax(50px, auto);
   width: 400px;
   margin: 0 auto;
+}
+
+.preview {
+  grid-column: 1 / 5;
+  background-color: #3a3a3a;
+  color: #aaa;
+  text-align: right;
+  padding-right: 10px;
+  font-size: 0.55em;
+  min-height: 1.2em;
 }
 
 .display {


### PR DESCRIPTION
Displays the running result above the main display while entering the second operand (e.g. typing 200 / 5 shows 40, extending to 200 / 50 updates it to 4). Also fixes the reversed operand order in equals() so the preview and = button produce consistent results.

https://claude.ai/code/session_015mznm4BJkCLTUahDqxz4wi